### PR TITLE
Minor fixes in qemu plugin

### DIFF
--- a/qemu/src/agents/plugins/qemu
+++ b/qemu/src/agents/plugins/qemu
@@ -24,7 +24,7 @@ if which virsh >/dev/null; then
             let MEM=MEM/1024
             PID=$(ps aux | grep kvm | grep $NAME | grep -v grep | awk '{print $2}')
             if [ $PID -gt 0 ]; then
-                    DATA=$(top -p $PID -n 1 -b | tail -1  | awk -- '{print $9" "$10}')
+                    DATA=$(top -p $PID -n 1 -b | sed '${/^$/d}' | tail -1 | awk -- '{print $9" "$10}')
             else
                     DATA=""
             fi

--- a/qemu/src/agents/plugins/qemu
+++ b/qemu/src/agents/plugins/qemu
@@ -22,8 +22,8 @@ if which virsh >/dev/null; then
             STATE=$(echo $L | awk '{print $3}')
             MEM=$(virsh dominfo $NAME | grep 'Used memory' | awk '{print $3}')
             let MEM=MEM/1024
-            PID=$(ps aux | grep kvm | grep $NAME | grep -v grep | awk '{print $2}')
-            if [ $PID -gt 0 ]; then
+            PID=$(pgrep -f -- "/qemu-kvm .*-name $NAME ")
+            if [ -n "$PID" ]; then
                     DATA=$(top -p $PID -n 1 -b | sed '${/^$/d}' | tail -1 | awk -- '{print $9" "$10}')
             else
                     DATA=""

--- a/qemu/src/checks/qemu
+++ b/qemu/src/checks/qemu
@@ -57,7 +57,7 @@ def check_qemu(item, params, info):
                 infotext.append("CPU: %s%%" % (current_cpu))
 
                 current_mem = int(round(float(line[5])))
-                infotext.append("Memory: (assined: %s MB, used: %s%%)" % (assigned_mem, current_mem))
+                infotext.append("Memory: (assigned: %s MB, used: %s%%)" % (assigned_mem, current_mem))
 
                 perfdata.append(("cpu_util", current_cpu))
                 perfdata.append(("memory_usage", current_mem))


### PR DESCRIPTION
* Allow VMs to have overlapping names
* EL6 top output might have a trailing newline. Strip it with sed. Closes #18.
* Spelling fix in plugin output text