### PR TITLE
feat(mysql_status): add InnoDB buffer pool utilization check

### DIFF
--- a/mysql_status/src/mysql_status/agent_based/mysql_status.py
+++ b/mysql_status/src/mysql_status/agent_based/mysql_status.py
@@ -199,3 +199,62 @@ check_plugin_mysql_status_query_types = CheckPlugin(
     discovery_function = discover_mysql_status_query_types,
     check_function = check_mysql_status_query_types,
 )
+
+
+def discover_mysql_innodb_buffer_pool_utilization(section):
+    for instance, data in section.items():
+        if "Innodb_buffer_pool_pages_total" in data and "Innodb_buffer_pool_pages_free" in data:
+            yield Service(item=instance)
+
+
+def check_mysql_innodb_buffer_pool_utilization(item, params, section):
+    if item not in section:
+        yield Result(state=State.UNKNOWN, summary="Instance data not found in output")
+        return
+
+    data = section[item]
+    total = data.get("Innodb_buffer_pool_pages_total")
+    free = data.get("Innodb_buffer_pool_pages_free")
+
+    if total is None or free is None:
+        yield Result(state=State.UNKNOWN, summary="Buffer pool page data not available")
+        return
+
+    if total == 0:
+        yield Result(state=State.UNKNOWN, summary="Buffer pool total pages is 0")
+        return
+
+    used = total - free
+    utilization = used / total * 100
+
+    state = State.OK
+    levels_info = ""
+    if "levels" in params:
+        warn, crit = params["levels"][1]
+        if utilization >= crit:
+            state = State.CRIT
+            levels_info = f" (warn/crit at {warn:.0f}/{crit:.0f}%)"
+        elif utilization >= warn:
+            state = State.WARN
+            levels_info = f" (warn/crit at {warn:.0f}/{crit:.0f}%)"
+
+    yield Metric(
+        name="mysql_status_innodb_buffer_pool_utilization",
+        value=utilization,
+        boundaries=(0.0, 100.0),
+    )
+    yield Result(
+        state=state,
+        summary=f"Utilization: {utilization:.1f}%{levels_info} ({used}/{total} pages, {free} free)",
+    )
+
+
+check_plugin_mysql_innodb_buffer_pool_utilization = CheckPlugin(
+    name="mysql_innodb_buffer_pool_utilization",
+    sections=["mysql"],
+    service_name="MySQL InnoDB Buffer Pool Utilization %s",
+    discovery_function=discover_mysql_innodb_buffer_pool_utilization,
+    check_function=check_mysql_innodb_buffer_pool_utilization,
+    check_default_parameters={},
+    check_ruleset_name="mysql_innodb_buffer_pool_utilization",
+)

--- a/mysql_status/src/mysql_status/graphing/mysql_status.py
+++ b/mysql_status/src/mysql_status/graphing/mysql_status.py
@@ -9,6 +9,7 @@ https://kuhn-ruess.de
 from cmk.graphing.v1.metrics import Metric, Title, Color, Unit, DecimalNotation, StrictPrecision
 
 UNIT_NUMBER = Unit(DecimalNotation(""), StrictPrecision(3))
+UNIT_PERCENTAGE = Unit(DecimalNotation("%"), StrictPrecision(1))
 
 metric_mysql_status_aborted_clients = Metric(
     name = "mysql_status_aborted_clients",
@@ -524,4 +525,17 @@ perfometer_mysql_status_open_files = Perfometer(
     name = "mysql_status_open_files",
     focus_range = FocusRange(Open(0), Open(40)),
     segments = ["mysql_status_open_files"],
+)
+
+metric_mysql_status_innodb_buffer_pool_utilization = Metric(
+    name = "mysql_status_innodb_buffer_pool_utilization",
+    title = Title("InnoDB buffer pool utilization"),
+    unit = UNIT_PERCENTAGE,
+    color = Color.BLUE,
+)
+
+perfometer_mysql_status_innodb_buffer_pool_utilization = Perfometer(
+    name = "mysql_status_innodb_buffer_pool_utilization",
+    focus_range = FocusRange(Open(0), Open(100)),
+    segments = ["mysql_status_innodb_buffer_pool_utilization"],
 )

--- a/mysql_status/src/mysql_status/rulesets/mysql_status.py
+++ b/mysql_status/src/mysql_status/rulesets/mysql_status.py
@@ -10,6 +10,7 @@ from cmk.rulesets.v1 import Help, Title
 from cmk.rulesets.v1.form_specs import (
     Dictionary,
     DictElement,
+    Float,
     InputHint,
     Integer,
     LevelDirection,
@@ -61,4 +62,37 @@ rule_spec_mysql_status = CheckParameters(
     condition = HostAndItemCondition(item_title = Title("Variable name")),
     topic = Topic.APPLICATIONS,
     parameter_form = _valuespec_mysql_status,
+)
+
+
+def _valuespec_mysql_innodb_buffer_pool_utilization():
+    return Dictionary(
+        title = Title("Settings for MySQL InnoDB buffer pool utilization check"),
+        help_text = Help(
+            "The InnoDB buffer pool utilization is calculated as "
+            "(pages_total - pages_free) / pages_total * 100. "
+            "Note that high utilization (>90%) is normal and desirable for production "
+            "databases — a full buffer pool means MySQL is caching data effectively. "
+            "Only alert if the pool is persistently at 100% with no free pages, "
+            "which may indicate the buffer pool size needs to be increased."
+        ),
+        elements = {
+            "levels": DictElement(
+                parameter_form = SimpleLevels(
+                    title = Title("Upper levels for buffer pool utilization (%)"),
+                    level_direction = LevelDirection.UPPER,
+                    form_spec_template = Float(unit_symbol="%"),
+                    prefill_fixed_levels = InputHint((95.0, 99.0)),
+                ),
+            ),
+        },
+    )
+
+
+rule_spec_mysql_innodb_buffer_pool_utilization = CheckParameters(
+    title = Title("MySQL InnoDB buffer pool utilization"),
+    name = "mysql_innodb_buffer_pool_utilization",
+    condition = HostAndItemCondition(item_title = Title("Instance name")),
+    topic = Topic.APPLICATIONS,
+    parameter_form = _valuespec_mysql_innodb_buffer_pool_utilization,
 )


### PR DESCRIPTION
## Summary

Adds a new check plugin `mysql_innodb_buffer_pool_utilization` that calculates InnoDB buffer pool utilization as:

```
(Innodb_buffer_pool_pages_total - Innodb_buffer_pool_pages_free) / Innodb_buffer_pool_pages_total * 100
```

This is equivalent to the metric many users know from Zabbix (`mysql.innodb_buffer_pool_pages_total` / `mysql.innodb_buffer_pool_pages_free`).

## How it works

The mk_mysql agent already collects both `Innodb_buffer_pool_pages_total` and `Innodb_buffer_pool_pages_free` via `SHOW STATUS`, so **no agent-side changes are needed**. The new check plugin reads from the existing `mysql` section.

## New service

One service is auto-discovered per MySQL instance:
> **MySQL InnoDB Buffer Pool Utilization mysql**
> Utilization: 99.9% (1556355/1557504 pages, 1149 free)

## Changes

- **agent_based/mysql_status.py**: new `mysql_innodb_buffer_pool_utilization` check plugin
- **graphing/mysql_status.py**: new percentage metric (`UNIT_PERCENTAGE`) + perfometer (0–100 range)
- **rulesets/mysql_status.py**: new rule `mysql_innodb_buffer_pool_utilization` with optional upper thresholds

## Threshold defaults

The check defaults to always-OK (no thresholds configured). The ruleset prefills warn/crit at **95%/99%** as a suggested starting point, since high utilization is normal and desirable — a full buffer pool means MySQL is caching data effectively. Users should only alert when the pool is persistently at 100%, which may indicate it needs to be increased.

## Testing

Verified against a production MariaDB instance where `Innodb_buffer_pool_pages_total` and `Innodb_buffer_pool_pages_free` are present in the mk_mysql agent output.